### PR TITLE
mobile: enable strict type checking and add runapp script

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,7 +3,8 @@
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "runapp": "./run.sh"
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.1.0",

--- a/mobile/run.sh
+++ b/mobile/run.sh
@@ -1,0 +1,13 @@
+yarn tsc;
+if [ $? -eq 1 ]
+then 
+  read -r -p "Typecheck failed! Continue building the app?" response
+  if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+  then
+      yarn $1
+  else
+      exit
+  fi
+else
+  yarn $1
+fi

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,11 +1,23 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "jsx": "react-native",
-    "lib": ["dom", "esnext"],
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": [
+      "es6"
+    ],
     "moduleResolution": "node",
     "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true
-  }
+    "strict": true,
+    "target": "esnext",
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "node_modules/*",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js",
+  ]
 }


### PR DESCRIPTION
Add the yarn runapp command. You can do yarn runapp ios or yarn runapp android
to run the app. It'll do a type check first and show you errors, then
give you the option to still proceed if you'd like.

I'm going to fix type errors currently in the app, and then eventually this will become a strict check so that we don't continue to have errors.