### PR TITLE
mobile: point app to prod server for production env

### DIFF
--- a/mobile/backend/backend.tsx
+++ b/mobile/backend/backend.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-community/async-storage';
 import CookieManager from '@react-native-community/cookies'
 
-export const BACKEND_URL = "http://localhost:5000/"
+export const BACKEND_URL = __DEV__ ? "http://localhost:5000/" : "https://app.imhelladown.com/"
 
 export const callBackend = async (endpoint: string, init: RequestInit = { headers: {} }) => {
     const sessionCookie = await AsyncStorage.getItem("sessionCookie")


### PR DESCRIPTION
Point the app to the prod server for the production environment.
I thought about making this through environment variables, but
I think its nice to be able to modify it in code and have it
be consistent throughout everyone's local copy of the code.