### PR TITLE
Close keyboard when tapping anywhere on screen

### DIFF
--- a/mobile/events/add_event.tsx
+++ b/mobile/events/add_event.tsx
@@ -64,7 +64,8 @@ const AddInfo = ({ navigation, route }) => {
       showEmojiPicker &&
       <View style={AddEventStyles.emoji_picker_container}>
         <EmojiSelector
-          category={Categories.symbols}
+          category={Categories.all}
+          showSearchBar={false}
           onEmojiSelected={emoji => {
             setEmojiPicked(emoji);
             setShowEmojiPicker(false);

--- a/mobile/events/edit_event.tsx
+++ b/mobile/events/edit_event.tsx
@@ -116,7 +116,8 @@ const EditEvent = (props) => {
       showEmojiPicker &&
       <View style={EditEventStyles.emoji_picker_container}>
         <EmojiSelector
-          category={Categories.symbols}
+          category={Categories.all}
+          showSearchBar={false}
           onEmojiSelected={emoji => {
             setEventEmoji(emoji);
             setShowEmojiPicker(false);

--- a/mobile/squads/add_squad.tsx
+++ b/mobile/squads/add_squad.tsx
@@ -69,6 +69,7 @@ const AddSquadModal = (props: OwnProps) => {
             id: squadId,
             name: squadName,
             squad_emoji: emojiPicked,
+            admin_id: props.admin_id
         }
         props.onPress(squad)
     }
@@ -92,7 +93,8 @@ const AddSquadModal = (props: OwnProps) => {
         return (
             showEmojiPicker &&
             <EmojiSelector
-                category={Categories.symbols}
+                category={Categories.all}
+                showSearchBar={false}
                 onEmojiSelected={emoji => {
                     setEmojiPicked(emoji);
                     setShowEmojiPicker(false);

--- a/mobile/squads/edit_squad.tsx
+++ b/mobile/squads/edit_squad.tsx
@@ -59,7 +59,8 @@ const EditSquad = (props) => {
             showEmojiPicker &&
             <View style = {EditSquadStyles.emoji_picker_container}>
             <EmojiSelector
-                category={Categories.symbols}
+                category={Categories.all}
+                showSearchBar={false}
                 onEmojiSelected={emoji => {
                     setSquadEmoji(emoji);
                     setShowEmojiPicker(false);


### PR DESCRIPTION
Wrapped the add squad modal content in a scrollview so that user can tap anywhere on screen to close the keyboard. Scrolling is disabled.

![Screen Recording 2020-08-12 at 12 26 56 PM](https://user-images.githubusercontent.com/3641891/90041734-b4d12800-dc97-11ea-83dc-a22f581b702a.gif)

Also set the searchbar in the EmojiSelector to false and the default category to all rather than symbols.