### PR TITLE
mobile: move add squad to its own page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -89,14 +89,14 @@ def add_to_squad():
 def createSquad():
     content = request.get_json()
     ok, err = validateArgsInRequest(
-        content, "email", "admin_id", "squad_name", "squad_emoji")
+        content, "email", "squad_name", "squad_emoji")
     if not ok:
         return err, 400
     email = content["email"]
     user = User.query.filter_by(email=email).first()
     if user is None:
         return 'User does not exist!', 400
-    squad = Squad(name=content["squad_name"], admin_id=content["admin_id"],
+    squad = Squad(name=content["squad_name"], admin_id=user.id,
                   squad_emoji=content["squad_emoji"])
     squad.generate_code()
     db.session.add(squad)

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Login from "./login/login";
-import AddSquadModal from "./squads/add_squad";
+import AddSquad from "./squads/add_squad";
 import "react-native-gesture-handler";
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
@@ -15,8 +15,13 @@ import { Ubuntu_400Regular, Ubuntu_400Regular_Italic, Ubuntu_700Bold, useFonts }
 import { Inter_400Regular } from '@expo-google-fonts/inter';
 import { AppLoading } from 'expo';
 
+export type RootStackParamList = {
+  AddSquad: {
+    email: string;
+  };
+};
 
-const Stack = createStackNavigator();
+const Stack = createStackNavigator<RootStackParamList>();
 
 export default function App() {
   const [fontsLoaded] = useFonts({
@@ -34,7 +39,7 @@ export default function App() {
           <Stack.Screen name="Login" component={Login} options={{ headerShown: false }} />
           <Stack.Screen name="Squads" component={Squads} />
           <Stack.Screen name="Edit Squad" component={EditSquad} />
-          <Stack.Screen name="Add Squad" component={AddSquadModal} />
+          <Stack.Screen name="Add Squad" component={AddSquad} />
           <Stack.Screen name="Events" component={Events} />
           <Stack.Screen name="Add Event" component={AddEvent} />
           <Stack.Screen name="EventDetails" component={EventDetails} />

--- a/mobile/squads/add_squad.tsx
+++ b/mobile/squads/add_squad.tsx
@@ -1,17 +1,25 @@
 import React, { useState } from "react";
-import { View, Modal, TextInput, Text, TouchableOpacity, SafeAreaView } from "react-native";
+import { View, TextInput, Text, TouchableOpacity, SafeAreaView } from "react-native";
 import { AddSquadStyles } from "./add_squad_styles"
 import EmojiSelector, { Categories } from "react-native-emoji-selector";
-import { Squad } from "./squads"
+import { RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
 import { callBackend } from "../backend/backend"
 import { ScrollView } from "react-native-gesture-handler";
+import { RootStackParamList } from "../App"
 
-type OwnProps = {
-    visible: boolean,
-    email: string,
-    admin_id: number,
-    onPress: (squad: Squad) => void
-}
+type AddSquadNavigationProp = StackNavigationProp<
+    RootStackParamList,
+    'AddSquad'
+>;
+
+type AddSquadRouteProp = RouteProp<RootStackParamList, 'AddSquad'>;
+
+type AddSquadProps = {
+    navigation: AddSquadNavigationProp;
+    route: AddSquadRouteProp
+};
+
 
 const DEFAULT_EMOJI = "😎"
 const ADD_SQUAD_BY_CODE_TITLE = "Have a Squad Code? Enter It Here"
@@ -20,19 +28,19 @@ const CREATE_NEW_SQUAD_TITLE = "Create A New Squad"
 const CREATE_NEW_SQUAD_PLACEHOLDER = "add squad name"
 const OR_TEXT = "OR"
 
-const AddSquadModal = (props: OwnProps) => {
-    const [squadId, setSquadId] = useState()
+const AddSquad = (props: AddSquadProps) => {
     const [squadName, setSquadName] = useState("")
     const [showSquadEmoji, setShowSquadEmoji] = useState(false)
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [emojiPicked, setEmojiPicked] = useState(DEFAULT_EMOJI);
     const [squadCode, setSquadCode] = useState("")
 
+    const email = props.route.params.email
+
     const addSquadOnBackend = () => {
         const endpoint = 'create_squad'
         const data = {
-            email: props.email,
-            admin_id: props.admin_id,
+            email: email,
             squad_name: squadName,
             squad_emoji: emojiPicked
         }
@@ -44,13 +52,13 @@ const AddSquadModal = (props: OwnProps) => {
                 'Content-Type': 'application/json'
             },
         }
-        callBackend(endpoint, init).then(() => { addSquad() })
+        callBackend(endpoint, init).then(() => { props.navigation.pop() })
     }
 
     const addSquadByCodeOnBackend = () => {
         const endpoint = 'add_to_squad'
         const data = {
-            email: props.email,
+            email: email,
             squad_code: squadCode
         }
         const init: RequestInit = {
@@ -61,33 +69,23 @@ const AddSquadModal = (props: OwnProps) => {
                 'Content-Type': 'application/json'
             },
         }
-        callBackend(endpoint, init).then(() => { addSquad() })
-    }
-
-    const addSquad = () => {
-        const squad: Squad = {
-            id: squadId,
-            name: squadName,
-            squad_emoji: emojiPicked,
-            admin_id: props.admin_id
-        }
-        props.onPress(squad)
+        callBackend(endpoint, init).then(() => { props.navigation.pop() })
     }
 
     const renderEmoji = () => {
         return showEmojiPicker ? (
             <Modal presentationStyle={"formSheet"} >
-                <EmojiSelector 
+                <EmojiSelector
                     showSearchBar={false}
                     onEmojiSelected={emoji => {
                         setEmojiPicked(emoji);
                         setShowEmojiPicker(false);
                     }} />
             </Modal>
-            ) : (
-            <TouchableOpacity onPress={() => setShowEmojiPicker(true)}>
-                <Text style={AddSquadStyles.emoji}>{emojiPicked}</Text>
-            </TouchableOpacity>
+        ) : (
+                <TouchableOpacity onPress={() => setShowEmojiPicker(true)}>
+                    <Text style={AddSquadStyles.emoji}>{emojiPicked}</Text>
+                </TouchableOpacity>
             );
     }
 
@@ -144,23 +142,18 @@ const AddSquadModal = (props: OwnProps) => {
     }
 
     return (
-        <Modal
-            transparent={false}
-            visible={props.visible}
-            presentationStyle={"formSheet"}
-        >
+        <View style={AddSquadStyles.container}>
             <ScrollView keyboardShouldPersistTaps="handled" scrollEnabled={false} >
-                <View style={AddSquadStyles.container}>
-                    {renderAddSquadByCode()}
-                    <Text style={AddSquadStyles.or_text}>
-                        {OR_TEXT}
-                    </Text>
-                    {renderCreateNewSquad()}
-                </View>
-            </ScrollView>
 
-        </Modal>
+                {renderAddSquadByCode()}
+                <Text style={AddSquadStyles.or_text}>
+                    {OR_TEXT}
+                </Text>
+                {renderCreateNewSquad()}
+            </ScrollView>
+        </View>
+
     );
 }
 
-export default AddSquadModal;
+export default AddSquad;

--- a/mobile/squads/add_squad_styles.tsx
+++ b/mobile/squads/add_squad_styles.tsx
@@ -5,7 +5,6 @@ export const AddSquadStyles = StyleSheet.create({
     flexDirection: "column",
     backgroundColor: "#fff",
     alignItems: "center",
-    marginTop: 50
   },
   add_container: {
     alignItems: "center",

--- a/mobile/squads/squads.tsx
+++ b/mobile/squads/squads.tsx
@@ -12,22 +12,26 @@ export type Squad = {
     id: number,
     name: string,
     squad_emoji: string,
-    code?: string,
+    code: string,
     admin_id: number
 }
 
 const Squads = (props) => {
-    const [addSquadModalVisble, setAddSquadModalVisble] = useState(false)
     const [squads, setSquads] = useState(props.route.params.squads)
     const [email, setEmail] = useState(props.route.params.email)
     const [userId, setUserId] = useState()
 
+    const goToAddSquad = () => {
+        props.navigation.navigate("Add Squad", {
+            email: email,
+        });
+    }
 
     useLayoutEffect(() => {
         props.navigation.setOptions({
             headerRight: () => (
                 <Button
-                    onPress={() => setAddSquadModalVisble(true)}
+                    onPress={() => goToAddSquad()}
                     title="Add"
                     color="#000"
                 />
@@ -69,16 +73,9 @@ const Squads = (props) => {
         React.useCallback(() => {
             getSquads();
             getUserId();
-      }, [])
+        }, [])
     );
 
-
-
-    const addSquad = (newSquad: Squad) => {
-        //setSquads(squads.concat([newSquad]));
-        setAddSquadModalVisble(false)
-        getSquads()
-    }
 
 
     const goToEvents = (id: number, name: string, squad_emoji: string, squad_code: string) => {
@@ -106,9 +103,9 @@ const Squads = (props) => {
                 'Content-Type': 'application/json'
             },
         }
-        callBackend(endpoint, init).then(response => { 
+        callBackend(endpoint, init).then(response => {
             return response.json();
-        }).then(data => { 
+        }).then(data => {
             setSquads(data.squads);
         });
     }
@@ -118,29 +115,29 @@ const Squads = (props) => {
         return (
             <TouchableOpacity
                 style={[squad_styles.backRightBtns, squad_styles.deleteBtn]}
-                onPress={() => 
+                onPress={() =>
                     Alert.alert(
                         'Alert',
-                        'Are you sure you want to delete ' + squadName   + '?',
+                        'Are you sure you want to delete ' + squadName + '?',
                         [
                             {
-                                text: 'Yes', 
+                                text: 'Yes',
                                 onPress: () => { deleteSquad(squadId) },
                             },
                             {
-                                text: 'Cancel', 
+                                text: 'Cancel',
                                 style: "cancel"
                             }
                         ],
-                        { cancelable: true}
+                        { cancelable: true }
                     )
-                    
+
                 }
             >
                 <Text style={squad_styles.deleteText}>Delete</Text>
             </TouchableOpacity>
         )
-    } 
+    }
 
     const goToEditSquad = (squadId: number, squadName: string, squadEmoji: string) => {
         props.navigation.navigate("Edit Squad", {
@@ -148,14 +145,13 @@ const Squads = (props) => {
             squadName: squadName,
             squadEmoji: squadEmoji
         });
-      }
+    }
 
     const editBtn = (squadId: number, squadName: string, squadEmoji: string) => {
         return (
             <TouchableOpacity
                 style={[squad_styles.backRightBtns, squad_styles.editBtn]}
-                onPress={() => 
-                    { goToEditSquad(squadId, squadName, squadEmoji) }
+                onPress={() => { goToEditSquad(squadId, squadName, squadEmoji) }
                 }
             >
                 <Text style={squad_styles.editText}>Edit</Text>
@@ -171,31 +167,25 @@ const Squads = (props) => {
             disableRightSwipe={true}
         >
             <View style={squad_styles.rowBack}>
-                { deleteBtn(item.id, item.name) }
-                { editBtn(item.id, item.name, item.squad_emoji) }
+                {deleteBtn(item.id, item.name)}
+                {editBtn(item.id, item.name, item.squad_emoji)}
             </View>
-            
-                <View style={squad_styles.rowFront}>
-                    <View style={squad_styles.squad_item}>
-                        <TouchableOpacity onPress={() => { goToEvents(item.id, item.name, item.squad_emoji, item.code) }}>
-                            <Text style={squad_styles.squad_text}>{item.squad_emoji} {item.name}</Text>
-                        </TouchableOpacity>
-                    </View>
+
+            <View style={squad_styles.rowFront}>
+                <View style={squad_styles.squad_item}>
+                    <TouchableOpacity onPress={() => { goToEvents(item.id, item.name, item.squad_emoji, item.code) }}>
+                        <Text style={squad_styles.squad_text}>{item.squad_emoji} {item.name}</Text>
+                    </TouchableOpacity>
                 </View>
+            </View>
         </SwipeRow>
     );
 
     return (
         <View style={squad_styles.squads_container}>
-            <SwipeListView 
-                data={squads} 
-                renderItem={renderSquadItem} 
-            />
-            <AddSquadModal
-                visible={addSquadModalVisble}
-                email={email}
-                admin_id={userId}
-                onPress={addSquad}
+            <SwipeListView
+                data={squads}
+                renderItem={renderSquadItem}
             />
         </View>
     );


### PR DESCRIPTION
In the process of fixing the cancelling adding a squad bug, I decided
to go ahead and move it to its own page so its consistent with adding
an event. I think it looks nicer and is better ux.

Also did some cleanup with admin_id

![Screen Shot 2020-08-12 at 7 50 59 PM](https://user-images.githubusercontent.com/3767300/90089398-28922580-dcd6-11ea-816f-05fba0aab6d3.png)
