### PR TITLE
mobile: force app to operate in light mode

### DIFF
--- a/mobile/backend/backend.tsx
+++ b/mobile/backend/backend.tsx
@@ -5,6 +5,7 @@ import CookieManager from '@react-native-community/cookies'
 // want to connect to your local backend
 // Download ngrok (https://dashboard.ngrok.com/get-started/setup)
 // Put the generated url here
+// export const BACKEND_URL = NGROK_URL
 export const BACKEND_URL = __DEV__ ? "http://localhost:5000/" : "https://app.imhelladown.com/"
 
 export const callBackend = async (endpoint: string, init: RequestInit = { headers: {} }) => {

--- a/mobile/ios/ImDown/Info.plist
+++ b/mobile/ios/ImDown/Info.plist
@@ -60,6 +60,8 @@
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Make the app operate in light mode, ignoring the user setting for
Dark mode for iOS. This fixes the datetimepicker issue.

The alternative would have been changing the appearance of the
datetimepicker based on dark mode. However, since the rest of our
app does not have a dark mode, I think it would have been weird
to only have the datetimepicker be dark mode and everything else
light, so instead I just decided to enforce light mode on our app.