### PR TITLE
Add tap for details on events page

### DIFF
--- a/mobile/events/events.tsx
+++ b/mobile/events/events.tsx
@@ -196,9 +196,14 @@ const Events = (props) => {
   return (
     <View style={event_styles.container}>
       <TouchableOpacity onPress={() => { goToSquadMembersPage(squadId) }}>
-        <Text style={event_styles.group_title}>
-          {squadEmoji} {squadName}
-        </Text>
+        <View style={event_styles.squad_name_emoji_container}>
+          <Text style={event_styles.group_title}>
+            {squadEmoji} {squadName}
+          </Text>
+          <Text style={event_styles.tap_for_details_text}>
+            Tap for details
+          </Text>
+        </View>
       </TouchableOpacity>
       {renderSquadCode()}
       <View style={event_styles.event_list_container}>

--- a/mobile/events/events_styles.tsx
+++ b/mobile/events/events_styles.tsx
@@ -82,7 +82,7 @@ export const event_styles = StyleSheet.create({
     borderColor: "#EEEEEE",
     borderWidth: 2,
     borderStyle: "solid",
-    marginTop: 10
+    marginTop: 20
   },
   squad_code: {
     paddingHorizontal: 25,
@@ -95,8 +95,19 @@ export const event_styles = StyleSheet.create({
     fontFamily: "Ubuntu_400Regular",
     fontSize: 20
   },
+  squad_name_emoji_container: {
+    flexDirection: 'column', 
+    justifyContent: "center", 
+    alignItems: "center"
+  },
   squad_code_value_text: {
     fontFamily: "Ubuntu_400Regular",
     fontSize: 20
+  },
+  tap_for_details_text: {
+    fontFamily: "Ubuntu_400Regular",
+    fontSize: 15,
+    color: "darkgray",
+    alignContent:"center"
   }
 });


### PR DESCRIPTION
Added  'Tap for details' below the squad name and emoji on the events page 

<img width="363" alt="Screen Shot 2020-08-17 at 9 50 05 PM" src="https://user-images.githubusercontent.com/3641891/90471650-a473df80-e0d3-11ea-8b77-8b8eafb30096.png">
