### PR TITLE
Change save button color on edit squad/event pages

### DIFF
--- a/mobile/events/edit_event_styles.tsx
+++ b/mobile/events/edit_event_styles.tsx
@@ -109,8 +109,8 @@ export const EditEventStyles = StyleSheet.create({
   save_button: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: "#68EDC6",
-    borderColor: "#aaaaaa",
+    backgroundColor: "#90BEDE",
+    borderColor: "#90BEDE",
     borderRadius: 30,
     borderWidth: 1,
     height: 75,
@@ -121,6 +121,7 @@ export const EditEventStyles = StyleSheet.create({
   save_button_text: {
     fontFamily: "Ubuntu_400Regular",
     fontSize: 30,
-  }
+    color: "white"
+  },
 });
 

--- a/mobile/squads/edit_squad_styles.tsx
+++ b/mobile/squads/edit_squad_styles.tsx
@@ -46,8 +46,8 @@ export const EditSquadStyles = StyleSheet.create({
   save_button: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: "#68EDC6",
-    borderColor: "#aaaaaa",
+    backgroundColor: "#90BEDE",
+    borderColor: "#90BEDE",
     borderRadius: 30,
     borderWidth: 1,
     height: 75,
@@ -58,6 +58,7 @@ export const EditSquadStyles = StyleSheet.create({
   save_button_text: {
     fontFamily: "Ubuntu_400Regular",
     fontSize: 30,
+    color: "white"
   },
   additional_fields_container: {
     backgroundColor: "#ffff",


### PR DESCRIPTION
Changed the save button color to match the done button the add squad page.

<img width="324" alt="Screen Shot 2020-08-18 at 6 25 22 PM" src="https://user-images.githubusercontent.com/3641891/90581471-2e798200-e180-11ea-830b-557f5a1d6539.png">
