### PR TITLE
Add event details page styling

### DIFF
--- a/mobile/events/AddEventDetailsScreen.tsx
+++ b/mobile/events/AddEventDetailsScreen.tsx
@@ -102,7 +102,7 @@ const AddEventDetailsScreen = ({ navigation, route }) => {
           <Tooltip
                 popover = { renderPopover() }
                 backgroundColor = "#90BEDE"
-                width = {220}
+                width = {240}
                 height = {120}
             >
             <Entypo name='info-with-circle' style={AddEventStyles.infoIcon}/>

--- a/mobile/events/add_event_styles.tsx
+++ b/mobile/events/add_event_styles.tsx
@@ -72,7 +72,7 @@ export const AddEventStyles = StyleSheet.create({
     flexDirection: "row", 
     alignItems: "center",
     marginLeft: 15,
-    marginTop: -25
+    marginTop: -15
   },
   emojiAndNameView: {
     flexDirection: "row", 


### PR DESCRIPTION
- Add more space between the start/end time.
<img width="295" alt="Screen Shot 2020-08-20 at 9 22 12 PM" src="https://user-images.githubusercontent.com/3641891/90852018-375a8700-e32b-11ea-8fb3-d7938c3032e8.png">

- Make the tooltip box bigger
<img width="361" alt="Screen Shot 2020-08-20 at 9 22 03 PM" src="https://user-images.githubusercontent.com/3641891/90852010-31fd3c80-e32b-11ea-93b5-c7093bc8a13d.png">


