### PR TITLE
mobile: fix bug with squad num on event page

### DIFF
--- a/mobile/backend/backend.tsx
+++ b/mobile/backend/backend.tsx
@@ -24,3 +24,15 @@ export const callBackend = async (endpoint: string, init: RequestInit = { header
     return fetch(BACKEND_URL + endpoint, init)
 }
 
+export const getUsersInSquad = (squadId: number) => {
+    const endpoint = 'get_users?squadId=' + squadId
+    const init: RequestInit = {
+        method: "GET",
+        headers: {
+            'Content-Type': 'application/json'
+        },
+    }
+    return callBackend(endpoint, init).then(response => {
+        return response.json();
+    })
+}

--- a/mobile/events/edit_event.tsx
+++ b/mobile/events/edit_event.tsx
@@ -12,7 +12,7 @@ import Slider from "@react-native-community/slider";
 const EditEvent = (props) => {
   const event = props.route.params.event
   const userEmail = props.route.params.userEmail
-
+  const numUsers = props.route.params.numUsers
   const [event_description, setEventDescription] = useState(event.description)
   const [event_down_threshold, setEventDownThreshold] = useState(event.down_threshold)
   const [event_emoji, setEventEmoji] = useState(event.emoji);
@@ -127,7 +127,7 @@ const EditEvent = (props) => {
       <View>
         <Text style={EditEventStyles.down_threshold_text}>Number of people down to create calendar event: {event_down_threshold}</Text>
         {/* Allowing a maximum value of at least 2 in case not everybody has joined. */}
-        <Slider minimumValue={1} maximumValue={Math.max(event.rsvp_users.length + event.declined_users.length, 2)} step={1}
+        <Slider minimumValue={1} maximumValue={Math.max(numUsers, 2)} step={1}
           value={event_down_threshold} onValueChange={setEventDownThreshold}
           thumbImage={require("../assets/down_static.png")}
           style={EditEventStyles.down_threshold_slider} />

--- a/mobile/squads/squad_members.tsx
+++ b/mobile/squads/squad_members.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from "react";
-import { View, Text, FlatList, Image, Alert, TouchableOpacity} from "react-native";
+import { View, Text, Image, Alert, TouchableOpacity } from "react-native";
 import { squad_members_styles } from "./squad_members_styles";
-import { callBackend } from "../backend/backend"
-import { User } from "../types/user"
+import { callBackend, getUsersInSquad } from "../backend/backend"
 import { SwipeListView, SwipeRow } from "react-native-swipe-list-view";
 
 const SquadMembers = (props) => {
@@ -10,19 +9,10 @@ const SquadMembers = (props) => {
     const [squadId, setSquadId] = useState(props.route.params.squadId)
 
     useEffect(() => {
-        const endpoint = 'get_users?squadId=' + squadId
-        const init: RequestInit = {
-            method: "GET",
-            headers: {
-            'Content-Type': 'application/json'
-            },
-        }
-        callBackend(endpoint, init).then(response => { 
-            return response.json();
-        }).then(data => { 
+        getUsersInSquad(squadId).then(data => {
             setUsers(convertToKeyValDict(data.user_info));
         });
-    }, []);  
+    }, []);
 
     const convertToKeyValDict = (users: any) => {
         return users.map((_, i) => ({ key: i, user: users[i] }))
@@ -42,9 +32,9 @@ const SquadMembers = (props) => {
                 'Content-Type': 'application/json'
             },
         }
-        callBackend(endpoint, init).then(response => { 
+        callBackend(endpoint, init).then(response => {
             return response.json();
-        }).then(data => { 
+        }).then(data => {
             setUsers(convertToKeyValDict(data.user_info));
         });
     }
@@ -57,8 +47,8 @@ const SquadMembers = (props) => {
                 [
                     {
                         text: 'Yes',
-                        onPress: () => { 
-                            deleteUser(id) 
+                        onPress: () => {
+                            deleteUser(id)
                         },
                     },
                     {
@@ -69,7 +59,7 @@ const SquadMembers = (props) => {
                 { cancelable: true }
             )
         )
-    } 
+    }
 
     const closeRow = (rowMap: any, rowKey: number) => {
         if (rowMap[rowKey]) {
@@ -84,13 +74,13 @@ const SquadMembers = (props) => {
                 onPress={() => {
                     closeRow(rowMap, rowKey);
                     alertPopUp(id, name);
-                  }   
+                }
                 }
             >
                 <Text style={squad_members_styles.deleteText}>Delete</Text>
             </TouchableOpacity>
         )
-    } 
+    }
 
 
     const renderUsersItem = (data: any, rowMap: any) => (
@@ -101,28 +91,28 @@ const SquadMembers = (props) => {
             <View style={squad_members_styles.rowBack}>
                 {deleteBtn(data.item.user.id, data.item.user.name, data.item.key, rowMap)}
             </View>
-            
-                <View style={squad_members_styles.rowFront}>
-                    <View style={squad_members_styles.user_info_view}>
-                        <View style={{paddingRight: 10}}>
-                            <Image style={squad_members_styles.user_image} source={{ uri: data.item.user.photo }} />
-                        </View>
-                        <View style={{paddingBottom: 8}}>
-                            <Text style={squad_members_styles.user_text}>{data.item.user.name} </Text>
-                        </View>
+
+            <View style={squad_members_styles.rowFront}>
+                <View style={squad_members_styles.user_info_view}>
+                    <View style={{ paddingRight: 10 }}>
+                        <Image style={squad_members_styles.user_image} source={{ uri: data.item.user.photo }} />
+                    </View>
+                    <View style={{ paddingBottom: 8 }}>
+                        <Text style={squad_members_styles.user_text}>{data.item.user.name} </Text>
                     </View>
                 </View>
+            </View>
         </SwipeRow>
     );
 
-  return (
-    <View style={squad_members_styles.squads_members_container}>
-        <SwipeListView 
-            data={users} 
-            renderItem={renderUsersItem} 
-        />
-    </View>
-  );
+    return (
+        <View style={squad_members_styles.squads_members_container}>
+            <SwipeListView
+                data={users}
+                renderItem={renderUsersItem}
+            />
+        </View>
+    );
 }
 
 export default SquadMembers;


### PR DESCRIPTION
When users join a squad which already has an event, the event details
page shows the wrong number for the total ppl in the squad. It calculates
it from the number of event responses. However, a new person joining the
squad does not have an event response so they are not counted in the
total amount.

This fixes the issue by fetching the total number of people in the squad
and using that for rsvp calculations. Also refactors a little bit to move
the get users call to  backend.tsx to make the code a little cleaner.

<img width="379" alt="Screen Shot 2020-08-24 at 8 31 25 PM" src="https://user-images.githubusercontent.com/3767300/91119922-4d2cbc80-e649-11ea-8aca-6e50f6536e4c.png">
