### PR TITLE
mobile: auto scroll view based on keyboard

### DIFF
--- a/mobile/events/AddEventDetailsScreen.tsx
+++ b/mobile/events/AddEventDetailsScreen.tsx
@@ -89,7 +89,7 @@ const AddEventDetailsScreen = ({ navigation, route }) => {
   const renderPopover = () => {
     return (
       <Text style={AddEventStyles.toolTipText}>
-        Once the minimum number of RSVPs is reached, the event is confirmed! Attendees will receive an invitation on Google Calendar. 
+        Once the minimum number of RSVPs is reached, the event is confirmed! Attendees will receive an invitation on Google Calendar.
       </Text>
     )
   }
@@ -100,19 +100,19 @@ const AddEventDetailsScreen = ({ navigation, route }) => {
         <View style={AddEventStyles.downThresholdAndIcon}>
           <Text style={AddEventStyles.downSliderText}>Minimum RSVPs Required: {downThreshold}   </Text>
           <Tooltip
-                popover = { renderPopover() }
-                backgroundColor = "#90BEDE"
-                width = {240}
-                height = {120}
-            >
-            <Entypo name='info-with-circle' style={AddEventStyles.infoIcon}/>
+            popover={renderPopover()}
+            backgroundColor="#90BEDE"
+            width={240}
+            height={120}
+          >
+            <Entypo name='info-with-circle' style={AddEventStyles.infoIcon} />
           </Tooltip>
         </View>
         {/* Allowing a maximum value of at least 2 in case not everybody has joined. */}
         <Slider minimumValue={1} maximumValue={Math.max(squadSize, 2)} step={1}
           value={downThreshold} onValueChange={setDownThreshold}
           thumbImage={require("../assets/down_static.png")}
-          style={AddEventStyles.downSlider} minimumTrackTintColor="#90BEDE"/>
+          style={AddEventStyles.downSlider} minimumTrackTintColor="#90BEDE" />
       </View>
     );
   };
@@ -173,11 +173,16 @@ const AddEventDetailsScreen = ({ navigation, route }) => {
         {/* Additional event information (more can be added here). */}
         {/* TODO: Create an image selector widget and fold it into the emoji selector. */}
         {/* <TextInput onChangeText={setImageUrl} placeholder="Image URL" style={AddEventStyles.optionalTextInput} /> */}
-        <TextInput onChangeText={setDescription} placeholder="Description" multiline={true} style={AddEventStyles.optionalTextInput} />
+        <TextInput
+          onChangeText={setDescription}
+          placeholder="Description"
+          multiline={true}
+          numberOfLines={3}
+          style={AddEventStyles.optionalTextInput} />
         {/* Slider to specify the required attendance for this event. */}
         {renderDownSlider()}
         <View style={AddEventStyles.nextButton}>
-          <Button onPress={addEventOnBackend} color= "#90BEDE" title="Let's go" />
+          <Button onPress={addEventOnBackend} color="#90BEDE" title="Let's go" />
         </View>
       </ScrollView>
     </View>

--- a/mobile/events/edit_event.tsx
+++ b/mobile/events/edit_event.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useState } from "react";
-import { Button, Image, SafeAreaView, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { Button, Image, SafeAreaView, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { EditEventStyles } from "./edit_event_styles";
 import EmojiPicker from "../components/emojipicker/EmojiPicker";
 import DateTimeInput from "../components/date_time_input/date_time_input";
@@ -8,6 +8,7 @@ import { callBackend } from "../backend/backend"
 import { IMG_URL_BASE_64_PREFIX } from "../constants"
 import ImagePicker from 'react-native-image-picker';
 import Slider from "@react-native-community/slider";
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
 const EditEvent = (props) => {
   const event = props.route.params.event
@@ -90,7 +91,13 @@ const EditEvent = (props) => {
         {/* {Divider()}
         <TextInput style={[EditEventStyles.event_url, { textDecorationLine: event_url ? 'underline' : 'none' }]} placeholder="Event URL" value={event_url} autoCapitalize={'none'} onChangeText={(value) => setEventURL(value)} /> */}
         {Divider()}
-        <TextInput style={EditEventStyles.event_description} placeholder="Event Description" value={event_description} multiline={true} onChangeText={(value) => setEventDescription(value)} />
+        <TextInput
+          style={EditEventStyles.event_description}
+          placeholder="Event Description"
+          value={event_description}
+          multiline={true}
+          numberOfLines={3}
+          onChangeText={setEventDescription} />
       </View>
     );
   }
@@ -175,7 +182,7 @@ const EditEvent = (props) => {
   }
 
   return (
-    <ScrollView style={EditEventStyles.container} >
+    <KeyboardAwareScrollView style={EditEventStyles.container} >
       {/* Event image */}
       {renderImageCircle()}
       {/* Event title */}
@@ -185,7 +192,7 @@ const EditEvent = (props) => {
       {/* Other additional event fields */}
       {renderAdditionalFieldsBox()}
       {renderSaveButton()}
-    </ScrollView>
+    </KeyboardAwareScrollView>
   );
 }
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -40,6 +40,7 @@
     "react-native-flash-message": "^0.1.16",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-image-picker": "^2.3.3",
+    "react-native-keyboard-aware-scroll-view": "^0.9.2",
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -6308,10 +6308,18 @@ react-native-image-picker@^2.3.3:
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-2.3.3.tgz#eaacd4a1ed9e9887613be31f0765478ca2f18a51"
   integrity sha512-i/7JDnxKkUGSbFY2i7YqFNn3ncJm1YlcrPKXrXmJ/YUElz8tHkuwknuqBd9QCJivMfHX41cmq4XvdBDwIOtO+A==
 
-react-native-iphone-x-helper@^1.2.1:
+react-native-iphone-x-helper@^1.0.3, react-native-iphone-x-helper@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+
+react-native-keyboard-aware-scroll-view@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.2.tgz#07df7adfa380af5816c0fbc500e3415077852f57"
+  integrity sha512-vlX+sZ6GogEcscZfQxMRi6Qm5BHRbntVaVF0GhHcc5RRs6ekk5Rxq+JsKIWVfym42cpEiLpFy3n4vb7jUgzhcw==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
 
 react-native-ratings@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
Make a fix so that the keyboard doesn't cover up the focused text
box and instead the view automatically adjusts for the edit event page.

I tried to do the same with the multiline inputs here and the add event page
but it has issues. I just decided to at least make the multiline inputs
scrollable by adding a number of lines attribute.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3767300/91141519-cab1f600-e664-11ea-8cef-ce08fdbb8e47.gif)

