### PR TITLE
backend: lint code with flake8 to find errors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,12 @@ jobs:
         pip install pytest
         cd backend
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ requests
 boto3
 pytest
 firebase-admin
+flake8


### PR DESCRIPTION
hopefully we stop breaking backend

taken from:
https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions

currently failing bc backend is broken rip