### PR TITLE
Configure ansible to use python3

### DIFF
--- a/deploy/ansible/inventory
+++ b/deploy/ansible/inventory
@@ -1,2 +1,2 @@
 [imdown]
-imdown
+imdown ansible_python_interpreter=auto


### PR DESCRIPTION
I'm not sure if this affects anyone else, but my ansible chose python2.7 for some reason. `ansible_python_interpreter=auto` will not become the default behavior until ansible 2.12 is released.