### PR TITLE
Remove redundant helper function for models

### DIFF
--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -98,7 +98,3 @@ class Event(db.Model):
             self.calendar_event_uuid = shortuuid.uuid()
             db.session.commit()
         return self.calendar_event_uuid
-
-
-def get_event_by_id(id):
-    return Event.query.filter_by(id=id).first()

--- a/backend/models/squad.py
+++ b/backend/models/squad.py
@@ -36,7 +36,3 @@ class Squad(db.Model):
 
     def jsonifySquad(self):
         return jsonify(id=self.id, squad_name=self.name, squad_emoji=self.squad_emoji, code=self.code, squad_id=self.id, admin_id=self.admin_id)
-
-def get_squad_by_id(id):
-    return Squad.query.filter_by(id=id).first()
-    

--- a/backend/models/squadmembership.py
+++ b/backend/models/squadmembership.py
@@ -1,6 +1,6 @@
 from init import db
 from flask import jsonify
-from models.user import User, get_user_by_id
+from models.user import User
 
 
 class SquadMembership(db.Model):
@@ -21,6 +21,6 @@ def GetUsersBySquadId(squad_id):
     users_lst = []
     for user_squad_membership in user_squad_memberships:
         user_id = user_squad_membership.user_id
-        user = get_user_by_id(user_id)
+        user = User.query.get(user_id)
         users_lst.append(user)
     return [user.userDict() for user in users_lst]

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -40,7 +40,3 @@ class User(UserMixin, db.Model):
         r = requests.post(oauth_url, data=refresh_body)
         resp = r.json()
         return resp['access_token']
-
-
-def get_user_by_id(id):
-    return User.query.filter_by(id=id).first()

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -1,4 +1,4 @@
-from models.user import get_user_by_id
+from models.user import User
 from models.squadmembership import SquadMembership
 import firebase_admin
 from firebase_admin import messaging
@@ -29,5 +29,5 @@ def notify_squad_members(squad_id, title, body="", users_to_exclude={}):
     device_tokens = []
     for sqm in squad_memberships:
         if sqm.user_id not in users_to_exclude:
-            device_tokens.append(get_user_by_id(sqm.user_id).device_token)
+            device_tokens.append(User.query.get(sqm.user_id).device_token)
     send_notification(device_tokens, title, body=body)


### PR DESCRIPTION
Our model class already has a built-in method, `<Model>.query.get` that behaves the same as `get_<model>_by_id`, so no helper function is needed.