### PR TITLE
backend: added scheduler & reminders to RSVP

### DIFF
--- a/backend/init.py
+++ b/backend/init.py
@@ -6,6 +6,8 @@ from extensions import db, migrate
 import os
 import json
 import boto3
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 
 
 login_manager = LoginManager()
@@ -49,3 +51,10 @@ def read_secrets():
 
 
 SECRETS = read_secrets()
+
+# Scheduler
+
+scheduler = BackgroundScheduler(jobstores={
+        'default': SQLAlchemyJobStore(url=Config.SQLALCHEMY_DATABASE_URI)
+        })
+scheduler.start()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ boto3
 pytest
 firebase-admin
 flake8
+apscheduler

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,0 +1,17 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from config import Config
+
+
+
+
+class Scheduler:
+
+    def __init__(self):
+        jobstores = {
+        'default': SQLAlchemyJobStore(url=Config.SQLALCHEMY_DATABASE_URI)
+        }
+        self.scheduler = BackgroundScheduler(jobstores=jobstores)
+        self.scheduler.start()
+
+    


### PR DESCRIPTION
Added APScheduler and set up a BackgroundScheduler that we can use
to schedule jobs at certain events. The jobs get stored in our db in
the apscheduler_jobs table. This table gets automatically created if
it doesn't exist when the app starts up.

I added a job to send a reminder to users to RSVP to an event if they
haven't accepted. The reminder is set 24 hours before the start of the
event and is updated if a user edits the event. This feature should
serve as an example of how to use the scheduler.

![IMG_2085](https://user-images.githubusercontent.com/3767300/91798546-fdff0280-ebd9-11ea-8c0b-27f1e1fcb380.jpg)
