### PR TITLE
backend: run uwsgi with enable-threads = true

### DIFF
--- a/backend/imdown.ini
+++ b/backend/imdown.ini
@@ -4,6 +4,7 @@ module = app:application
 
 master = true
 processes = 1
+enable-threads = true
 
 logto = /var/log/uwsgi/%n.log
 


### PR DESCRIPTION
We need this for APScheduler to function properly. Tested this to make sure it fixed the server.