### PR TITLE
mobile: fix datetime bug in addevent

### DIFF
--- a/mobile/events/AddEvent.tsx
+++ b/mobile/events/AddEvent.tsx
@@ -118,6 +118,7 @@ const AddEvent = ({ route, navigation }: AddEventProps) => {
     <Section label='Start and end times'>
       <DateTimeInput
         onSetDateTime={setStartDateTime}
+        initialDateTime={startDateTime}
       />
       {showEndTime
         ? (


### PR DESCRIPTION
The start datetime wouldn't refresh to the current time after the first time the AddEvent page was loaded. Fix that by passing in the current time as the initial date time for the start DateTimeInput component