### PR TITLE
Fixes for blur modal cancel

### DIFF
--- a/mobile/components/blurmodal/BlurModal.tsx
+++ b/mobile/components/blurmodal/BlurModal.tsx
@@ -9,21 +9,24 @@ import BlurModalStyles from './BlurModalStyles';
 
 type BlurModalProps = {
   children: React.ReactNode;
-  cancel?: () => void;
+  isCancelVisible?: boolean;
+  onCancel?: () => void;
   visible: boolean;
 };
 
 const exitButton = require('../../assets/exit_button.png');
 
 const BlurModal = (props: BlurModalProps) => {
-  const { visible, cancel, children } = props;
+  const {
+    visible, isCancelVisible, onCancel, children,
+  } = props;
   return (
     <Modal visible={visible} animationType='fade' transparent>
       <View style={BlurModalStyles.modalBackgroundBlur}>
         <View style={BlurModalStyles.modalVisibleContainer}>
-          {(cancel)
+          {(isCancelVisible)
             ? (
-              <TouchableOpacity onPress={cancel} style={BlurModalStyles.exitButtonContainer}>
+              <TouchableOpacity onPress={onCancel} style={BlurModalStyles.exitButtonContainer}>
                 <Image source={exitButton} style={BlurModalStyles.exitButton} />
               </TouchableOpacity>
             ) : null}
@@ -42,7 +45,8 @@ const BlurModal = (props: BlurModalProps) => {
 };
 
 BlurModal.defaultProps = {
-  cancel: () => {},
+  isCancelVisible: false,
+  onCancel: undefined,
 };
 
 export default BlurModal;

--- a/mobile/components/date_time_input/DateTimeModal.tsx
+++ b/mobile/components/date_time_input/DateTimeModal.tsx
@@ -19,7 +19,8 @@ const DateTimeModal = (props: DateTimeModalProps) => {
   return (
     <BlurModal
       visible={visible}
-      cancel={() => {
+      isCancelVisible
+      onCancel={() => {
         setDateTime(props.initialDateTime);
         props.hideDatePicker();
       }}

--- a/mobile/components/imageuploader/ImageUploader.tsx
+++ b/mobile/components/imageuploader/ImageUploader.tsx
@@ -64,7 +64,11 @@ const ImageUploader = (props: ImageUploaderProps) => {
       <TouchableOpacity style={touchableStyle} onPress={() => onImageUploaderToggled()}>
         {children}
       </TouchableOpacity>
-      <BlurModal visible={uploadImageModal} cancel={() => setUploadImageModal(false)}>
+      <BlurModal
+        visible={uploadImageModal}
+        isCancelVisible
+        onCancel={() => setUploadImageModal(false)}
+      >
         <StandardButton text='Take photo from camera' onPress={() => pickImageFromCamera()} />
         <StandardButton text='Choose photo from gallery' overrideStyle={ImageUploaderStyles.chooseFromGalleryButton} onPress={() => pickImageFromGallery()} />
         {currentImage ? <StandardButton text='Remove image' overrideStyle={ImageUploaderStyles.deleteImageButton} onPress={() => deleteImage()} /> : <View /> }

--- a/mobile/squads/Squads.tsx
+++ b/mobile/squads/Squads.tsx
@@ -15,7 +15,6 @@ import TextStyles from '../TextStyles';
 import { callBackend, deleteRequest } from '../backend/backend';
 import ButtonBottomSheet from '../components/bottomsheet/ButtonBottomSheet';
 import StandardButton from '../components/button/Button';
-import BlurModal from '../components/blurmodal/BlurModal';
 import AppNavRouteProp from '../types/navigation';
 
 export type Squad = {
@@ -37,7 +36,6 @@ const Squads = ({ route, navigation }: SquadsProps) => {
   const [squads, setSquads] = useState([]);
   const [email, setEmail] = useState(route.params.email); // eslint-disable-line no-unused-vars
   const [userId, setUserId] = useState();
-  const [addSquadModal, setAddSquadModal] = useState(false);
 
   const hideBottomSheet = () => {
     setBottomSheetRefIndex(0);
@@ -216,7 +214,7 @@ const Squads = ({ route, navigation }: SquadsProps) => {
       >
         Add a squad to get started planning your next hangout.
       </Text>
-      <StandardButton text='Add a squad' onPress={() => setAddSquadModal(true)} />
+      <StandardButton text='Add a squad' onPress={() => (bottomSheetRefIndex ? hideBottomSheet() : showBottomSheet())} />
     </View>
   );
 
@@ -275,13 +273,6 @@ const Squads = ({ route, navigation }: SquadsProps) => {
     </SwipeRow>
   );
 
-  const renderAddSquadModal = () => (
-    <BlurModal visible={addSquadModal} cancel={() => setAddSquadModal(false)}>
-      <StandardButton text='Join an existing squad' onPress={() => goToAddExistingSquad()} />
-      <StandardButton text='Create a new squad' overrideStyle={{ marginTop: 10, marginBottom: 30 }} onPress={() => goToAddNewSquad()} />
-    </BlurModal>
-  );
-
   return (
     <View style={SquadsStyles.squadsContainer}>
       {renderSearchButton()}
@@ -295,7 +286,6 @@ const Squads = ({ route, navigation }: SquadsProps) => {
           renderItem={renderSquadItem}
         />
       ) : renderNoSquadsView()}
-      {renderAddSquadModal()}
       <ButtonBottomSheet
         sheetRef={sheetRef}
         hideBottomSheet={hideBottomSheet}


### PR DESCRIPTION
Setting `cancel` field in `BlurModal` to default to `undefined`, rather than `() => {}`, so that passing in nothing for `cancel` results in no cancel button showing.